### PR TITLE
webpack parity

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,8 +1,8 @@
-import { start } from "web";
+import init from "web";
 
 export const runApp = () => {
   try {
-    start();
+    init();
     console.log("WASM Loaded");
   } catch (e) {
     console.error(e);

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, ".."),
       outName: 'graphics_toolbox',
+      extraArgs: '--target web',
     }),
   ],
   experiments: {


### PR DESCRIPTION
should allow both python and webpack to use the same `pkg/` files